### PR TITLE
chore: use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,9 @@ ouputs:
   prDirtyStatuses:
     description: 'Object-map. The keys are pull request numbers and their values whether a PR is dirty or not.'
 runs:
-  using: "node20"
-  main: "dist/index.js"
-author: "Sebastian Silbermann"
+  using: 'node20'
+  main: 'dist/index.js'
+author: 'Sebastian Silbermann'
 branding:
   icon: 'activity'
   color: 'black'


### PR DESCRIPTION
Bump to node 20 to get rid of the deprecation warnings